### PR TITLE
fix for undefined in search results

### DIFF
--- a/src/static/js/search.js
+++ b/src/static/js/search.js
@@ -20,7 +20,6 @@ function callSearch(text) {
             jsonReturn = jsonReturn.filter((item) => item.docType == 'VideoEpisode')
             for(var i = 0; i < jsonReturn.length; i++) {
                 $('.searchresponse').append(`<p><a href="/show?id=${jsonReturn[i].id}">${jsonReturn[i].title}</a></p>`)
-                }
             }
         }
     }

--- a/src/static/js/search.js
+++ b/src/static/js/search.js
@@ -12,7 +12,7 @@ function callSearch(text) {
     var xhr = new XMLHttpRequest();
     xhr.onreadystatechange = function() {
         if (xhr.readyState == XMLHttpRequest.DONE) {
-            var jsonReturn = JSON.parse(xhr.response).results[0].hits
+            let jsonReturn = JSON.parse(xhr.response).results[0].hits
             // filter response results, dont include anything without an id or a title
             jsonReturn = jsonReturn.filter((item) => typeof item.id !== 'undefined')
             jsonReturn = jsonReturn.filter((item) => typeof item.title !== 'undefined')
@@ -28,7 +28,8 @@ function callSearch(text) {
         "requests": [
             {
                 "indexName": "ABC_production_iview_web",
-                "params": "query=" + text
+                "params": "query=" + text,
+                "hitsPerPage": 25
             }
         ]
     }));

--- a/src/static/js/search.js
+++ b/src/static/js/search.js
@@ -13,14 +13,13 @@ function callSearch(text) {
     xhr.onreadystatechange = function() {
         if (xhr.readyState == XMLHttpRequest.DONE) {
             var jsonReturn = JSON.parse(xhr.response).results[0].hits
-            // filter response results, dont include anything without an id
+            // filter response results, dont include anything without an id or a title
             jsonReturn = jsonReturn.filter((item) => typeof item.id !== 'undefined')
+            jsonReturn = jsonReturn.filter((item) => typeof item.title !== 'undefined')
             // dont include anything that isnt a 'VideoEpisode'
             jsonReturn = jsonReturn.filter((item) => item.docType == 'VideoEpisode')
             for(var i = 0; i < jsonReturn.length; i++) {
-                var title = jsonReturn[i].title
-                if(title != 'undefined') {
-                    $('.searchresponse').append(`<p><a href="/show?id=${jsonReturn[i].id}">${title}</a></p>`)
+                $('.searchresponse').append(`<p><a href="/show?id=${jsonReturn[i].id}">${jsonReturn[i].title}</a></p>`)
                 }
             }
         }

--- a/src/static/js/search.js
+++ b/src/static/js/search.js
@@ -14,6 +14,9 @@ function callSearch(text) {
         if (xhr.readyState == XMLHttpRequest.DONE) {
             var jsonReturn = JSON.parse(xhr.response).results[0].hits
             for(var i = 0; i < jsonReturn.length; i++) {
+                // skip episodes that dont contain an id
+                if (typeof jsonReturn[i].id === "undefined")
+                    continue
                 var title = jsonReturn[i].title
                 if(title != 'undefined') {
                     $('.searchresponse').append(`<p><a href="/show?id=${jsonReturn[i].id}">${title}</a></p>`)

--- a/src/static/js/search.js
+++ b/src/static/js/search.js
@@ -14,9 +14,13 @@ function callSearch(text) {
         if (xhr.readyState == XMLHttpRequest.DONE) {
             var jsonReturn = JSON.parse(xhr.response).results[0].hits
             for(var i = 0; i < jsonReturn.length; i++) {
-                // skip episodes that dont contain an id
+                // skip items that dont contain an id or 
                 if (typeof jsonReturn[i].id === "undefined")
                     continue
+                // skip items that arent docType "VideoEpisode"
+                if (jsonReturn[i].docType !== "VideoEpisode")
+                    continue
+
                 var title = jsonReturn[i].title
                 if(title != 'undefined') {
                     $('.searchresponse').append(`<p><a href="/show?id=${jsonReturn[i].id}">${title}</a></p>`)

--- a/src/static/js/search.js
+++ b/src/static/js/search.js
@@ -13,14 +13,11 @@ function callSearch(text) {
     xhr.onreadystatechange = function() {
         if (xhr.readyState == XMLHttpRequest.DONE) {
             var jsonReturn = JSON.parse(xhr.response).results[0].hits
+            // filter response results, dont include anything without an id
+            jsonReturn = jsonReturn.filter((item) => typeof item.id !== 'undefined')
+            // dont include anything that isnt a 'VideoEpisode'
+            jsonReturn = jsonReturn.filter((item) => item.docType == 'VideoEpisode')
             for(var i = 0; i < jsonReturn.length; i++) {
-                // skip items that dont contain an id or 
-                if (typeof jsonReturn[i].id === "undefined")
-                    continue
-                // skip items that arent docType "VideoEpisode"
-                if (jsonReturn[i].docType !== "VideoEpisode")
-                    continue
-
                 var title = jsonReturn[i].title
                 if(title != 'undefined') {
                     $('.searchresponse').append(`<p><a href="/show?id=${jsonReturn[i].id}">${title}</a></p>`)


### PR DESCRIPTION
Sometimes the iview api returns results that dont actually exist, ie they dont have an id or title, this results in 'undefined' entries in the search results.