### PR TITLE
Fix invalid HTML

### DIFF
--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <%- include ('_headcontent'); %>
         <title>iView Proxy</title>

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -2,6 +2,7 @@
 <html>
     <head>
         <%- include ('_headcontent'); %>
+        <title>iView Proxy</title>
     </head>
     <body>
         <%- include('_header'); %>

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
     <head>
         <%- include ('_headcontent'); %>

--- a/src/views/show.ejs
+++ b/src/views/show.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <%- include ('_headcontent'); %>
         <title>iView Proxy - <%= query.id %></title>

--- a/src/views/show.ejs
+++ b/src/views/show.ejs
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
     <head>
         <%- include ('_headcontent'); %>


### PR DESCRIPTION
- Fix error: missing doctype in index & show
- Fix error: missing head title element in index
- Fix warning: missing lang attribute in index & show

Both index and show HTML now fully validate with no warnings
according to <https://validator.w3.org/>.
